### PR TITLE
Correct the permissions checks

### DIFF
--- a/admin-bar-user-switching.php
+++ b/admin-bar-user-switching.php
@@ -68,8 +68,8 @@ function abus_adminbar_output() {
 		/* load the global admin bar variable */
 		global $wp_admin_bar;
 			
-		/* check whether the current user is super admin */
-		if( current_user_can( 'switch_to_user' ) ) {
+		/* check whether the current user can edit users */
+		if( current_user_can( 'edit_users' ) ) {
 		
 			/* add admin bar menu for switching to a user */
 			$wp_admin_bar->add_menu(
@@ -162,7 +162,11 @@ function abus_user_search() {
 		/* loop through each returned user */
 		foreach ( $user_query->results as $user ) {
 			
-			echo '<p class="result"><a href="' . $user_switching->switch_to_url( $user ).'&redirect_to=' . esc_url( $url ) . '">' . $user->display_name . '</a></p>';
+			$link = user_switching::maybe_switch_url( $user );
+			if ( $link ) {
+				$link = add_query_arg( 'redirect_to', $url, $link );
+				echo '<p class="result"><a href="' . esc_url( $link ) . '">' . $user->display_name . '</a></p>';
+			}
 			
 		}
 	


### PR DESCRIPTION
User Switching in Admin Bar is incorrectly checking capabilities. The `switch_to_user` capability requires a user ID to be passed along with it.

User Switching doesn't have a global "can a user switch users?" sort of capability, rather the capability is checked against each user that you're trying to switch to.

A better cap to use when you're deciding to show the 'Switch to User' menu would be `edit_users`. User Switching's capability maps to the ability to edit the user you're trying to switch to anyway.

In addition, you can use User Switching's `maybe_switch_url()` method when fetching the switch link for each user. It's is a wrapper function for a capability check and returning the switch URL.