### PR TITLE
Keyboard navigation, wildcard search, and input auto-focus

### DIFF
--- a/admin-bar-user-switching.php
+++ b/admin-bar-user-switching.php
@@ -154,7 +154,8 @@ function abus_user_search() {
 	$args = apply_filters(
 		'abus_user_search_args',
 		array(
-			'search'	=> $q,
+			'search'	=> '*' . $q . '*',
+			'search_columns' => array( 'user_login', 'user_email', 'user_nicename' ),
 		)
 	);
 	

--- a/admin-bar-user-switching.php
+++ b/admin-bar-user-switching.php
@@ -154,8 +154,7 @@ function abus_user_search() {
 	$args = apply_filters(
 		'abus_user_search_args',
 		array(
-			'search'	=> '*' . $q . '*',
-			'search_columns' => array( 'user_login', 'user_email', 'user_nicename' ),
+			'search'	=> is_numeric( $q ) ? $q : '*' . $q . '*',
 		)
 	);
 	

--- a/assets/js/abus_script.js
+++ b/assets/js/abus_script.js
@@ -1,49 +1,88 @@
-jQuery(document).on( 'submit', '#abus_wrapper form', function() {
-	
-	/* get the form */
-	var $form = jQuery(this);
-	
-	/* get the form input for searching */
-    var $input = $form.find('input[name="abus_search_text"]');
-    
-    /* get the value of our search input */
-    var query = $input.val();
-    
-    /* get the form input for current url */
-    var $currenturl = $form.find('input[name="abus_current_url"]');
-    
-    /* get the value of the current url */
-    var currenturl = $currenturl.val();
-    
-    /* get the nonce */
-    var $nonce = $form.find('input[name="abus_nonce"]');
-    
-    /* get the nonce value */
-    var nonce = $nonce.val();
-    
-    /* get the results div */
-    var $content = jQuery('#abus_result');
-    
-	jQuery.ajax({
-		type : 'post',
-		url : abus_ajax.ajaxurl,
-		data : {
-			action : 'abus_user_search',
-			query : query,
-			currenturl : currenturl,
-			nonce : nonce
-		},
-		beforeSend: function() {
-			$input.prop('disabled', true);
-			$content.addClass('loading');
-		},
-		success : function( response ) {
-			$input.prop('disabled', false);
-			$content.removeClass('loading');
-			$content.html( response );
+jQuery( function( $ ) {
+
+	var entryButton = $( '#wp-admin-bar-abus_switch_to_user > a' ),
+	    $wrapper    = $( '#abus_wrapper' ),
+	    $form       = $wrapper.find( 'form' ),
+	    $input      = $form.find( 'input[name="abus_search_text"]' ),
+	    currenturl  = $form.find( 'input[name="abus_current_url"]' ).val(),
+	    nonce       = $form.find( 'input[name="abus_nonce"]' ).val(),
+	    $content    = $wrapper.find( '#abus_result' )
+		;
+
+
+	// Clicking the admin-bar entry focuses the text box
+	entryButton.on( 'click', function() {
+		$input.focus();
+
+		return false;
+	} );
+
+	// Navigate through results using arrows
+	$wrapper.on( 'keydown', '.result', function( ev ) {
+		var results = $wrapper.find( '.abus_user_results .result' ),
+		    active  = results.filter( '.active' ),
+		    idx     = 0;
+
+		if ( results.length < 2 ) {
+			return;
 		}
-	});
-	
-	return false;
-    
-})
+
+		if ( 0 == active.length ) {
+			active = results.eq( 0 ).addClass( 'active' );
+		}
+
+		// Down
+		if ( 40 == ev.which ) {
+			idx = results.index( active );
+			if ( results.length - idx > 1 ) {
+				active.removeClass( 'active' );
+				results.eq( idx + 1 ).addClass( 'active' ).find( 'a' ).focus();
+
+				return false;
+			}
+		}
+		// Up
+		else if ( 38 == ev.which ) {
+			idx = results.index( active );
+			if ( idx > 0 ) {
+				active.removeClass( 'active' );
+				results.eq( idx - 1 ).addClass( 'active' ).find( 'a' ).focus();
+
+				return false;
+			}
+		}
+	} );
+
+	// Form submission / user search
+	$form.submit( function() {
+
+		var query = $input.val();
+
+		$.ajax( {
+			        type : 'post',
+			        url : abus_ajax.ajaxurl,
+			        data : {
+				        action : 'abus_user_search',
+				        query : query,
+				        currenturl : currenturl,
+				        nonce : nonce
+			        },
+			        beforeSend : function() {
+				        $input.prop( 'disabled', true );
+				        $content.addClass( 'loading' );
+			        },
+			        success : function( response ) {
+				        $input.prop( 'disabled', false );
+				        $content.removeClass( 'loading' );
+				        $content.html( response );
+
+				        // Focus the first result
+				        $content.find( '.result:eq(0)' ).addClass( 'active' )
+					        .find( 'a' ).focus();
+			        }
+		        } );
+
+		return false;
+
+	} )
+} );

--- a/assets/js/abus_script.js
+++ b/assets/js/abus_script.js
@@ -84,5 +84,5 @@ jQuery( function( $ ) {
 
 		return false;
 
-	} )
+	} );
 } );


### PR DESCRIPTION
This adds the following:

1. Keyboard navigation:
Once you hit search, and results are back, you can now use the keyboard to navigate between results, hit enter to switch to the selected user. Or just hit enter to switch to the first user (automatically selected).

2. Wildcard Search
You can now search in users using only part of their name, and get all matches

3. Search input focus
Input is now auto-focused upon clicking the 'Switch To User' admin-bar entry, to save the extra click

This also refactors the JS file a bit to account for the new changes.