### PR TITLE
Switch to users, off, using keyboard only and word combination

### DIFF
--- a/admin-bar-user-switching.php
+++ b/admin-bar-user-switching.php
@@ -154,7 +154,8 @@ function abus_user_search() {
 	$args = apply_filters(
 		'abus_user_search_args',
 		array(
-			'search'	=> $q,
+			'search'	=> '*' . $q . '*',
+			'search_columns' => array( 'user_login', 'user_email', 'user_nicename' ),
 		)
 	);
 	

--- a/admin-bar-user-switching.php
+++ b/admin-bar-user-switching.php
@@ -208,13 +208,18 @@ function abus_enqueue_scripts() {
 		plugins_url( '/assets/js/abus_script.js', __FILE__ ),
 		array( 'jquery' )
 	);
-	
+
+	$args = array(
+		'ajaxurl' => admin_url( 'admin-ajax.php' )
+		'magicWord' => '',
+	);
+
+	$args = apply_filters( 'abus_ajax_args', $args );
+
 	wp_localize_script(
 		'abus_script',
 		'abus_ajax',
-		array(
-			'ajaxurl' => admin_url( 'admin-ajax.php' )
-		)
+		$args
 	);        
 	
 	wp_enqueue_script( 'jquery' );

--- a/admin-bar-user-switching.php
+++ b/admin-bar-user-switching.php
@@ -154,8 +154,7 @@ function abus_user_search() {
 	$args = apply_filters(
 		'abus_user_search_args',
 		array(
-			'search'	=> '*' . $q . '*',
-			'search_columns' => array( 'user_login', 'user_email', 'user_nicename' ),
+			'search'	=> is_numeric( $q ) ? $q : '*' . $q . '*',
 		)
 	);
 	

--- a/assets/js/abus_script.js
+++ b/assets/js/abus_script.js
@@ -1,49 +1,88 @@
-jQuery(document).on( 'submit', '#abus_wrapper form', function() {
-	
-	/* get the form */
-	var $form = jQuery(this);
-	
-	/* get the form input for searching */
-    var $input = $form.find('input[name="abus_search_text"]');
-    
-    /* get the value of our search input */
-    var query = $input.val();
-    
-    /* get the form input for current url */
-    var $currenturl = $form.find('input[name="abus_current_url"]');
-    
-    /* get the value of the current url */
-    var currenturl = $currenturl.val();
-    
-    /* get the nonce */
-    var $nonce = $form.find('input[name="abus_nonce"]');
-    
-    /* get the nonce value */
-    var nonce = $nonce.val();
-    
-    /* get the results div */
-    var $content = jQuery('#abus_result');
-    
-	jQuery.ajax({
-		type : 'post',
-		url : abus_ajax.ajaxurl,
-		data : {
-			action : 'abus_user_search',
-			query : query,
-			currenturl : currenturl,
-			nonce : nonce
-		},
-		beforeSend: function() {
-			$input.prop('disabled', true);
-			$content.addClass('loading');
-		},
-		success : function( response ) {
-			$input.prop('disabled', false);
-			$content.removeClass('loading');
-			$content.html( response );
+jQuery( function( $ ) {
+
+	var entryButton = $( '#wp-admin-bar-abus_switch_to_user > a' ),
+	    $wrapper    = $( '#abus_wrapper' ),
+	    $form       = $wrapper.find( 'form' ),
+	    $input      = $form.find( 'input[name="abus_search_text"]' ),
+	    currenturl  = $form.find( 'input[name="abus_current_url"]' ).val(),
+	    nonce       = $form.find( 'input[name="abus_nonce"]' ).val(),
+	    $content    = $wrapper.find( '#abus_result' )
+		;
+
+
+	// Clicking the admin-bar entry focuses the text box
+	entryButton.on( 'click', function() {
+		$input.focus();
+
+		return false;
+	} );
+
+	// Navigate through results using arrows
+	$wrapper.on( 'keydown', '.result', function( ev ) {
+		var results = $wrapper.find( '.abus_user_results .result' ),
+		    active  = results.filter( '.active' ),
+		    idx     = 0;
+
+		if ( results.length < 2 ) {
+			return;
 		}
-	});
-	
-	return false;
-    
-})
+
+		if ( 0 == active.length ) {
+			active = results.eq( 0 ).addClass( 'active' );
+		}
+
+		// Down
+		if ( 40 == ev.which ) {
+			idx = results.index( active );
+			if ( results.length - idx > 1 ) {
+				active.removeClass( 'active' );
+				results.eq( idx + 1 ).addClass( 'active' ).find( 'a' ).focus();
+
+				return false;
+			}
+		}
+		// Up
+		else if ( 38 == ev.which ) {
+			idx = results.index( active );
+			if ( idx > 0 ) {
+				active.removeClass( 'active' );
+				results.eq( idx - 1 ).addClass( 'active' ).find( 'a' ).focus();
+
+				return false;
+			}
+		}
+	} );
+
+	// Form submission / user search
+	$form.submit( function() {
+
+		var query = $input.val();
+
+		$.ajax( {
+			        type : 'post',
+			        url : abus_ajax.ajaxurl,
+			        data : {
+				        action : 'abus_user_search',
+				        query : query,
+				        currenturl : currenturl,
+				        nonce : nonce
+			        },
+			        beforeSend : function() {
+				        $input.prop( 'disabled', true );
+				        $content.addClass( 'loading' );
+			        },
+			        success : function( response ) {
+				        $input.prop( 'disabled', false );
+				        $content.removeClass( 'loading' );
+				        $content.html( response );
+
+				        // Focus the first result
+				        $content.find( '.result:eq(0)' ).addClass( 'active' )
+					        .find( 'a' ).focus();
+			        }
+		        } );
+
+		return false;
+
+	} )
+} );

--- a/assets/js/abus_script.js
+++ b/assets/js/abus_script.js
@@ -84,5 +84,5 @@ jQuery( function( $ ) {
 
 		return false;
 
-	} )
+	} );
 } );

--- a/assets/js/abus_script.js
+++ b/assets/js/abus_script.js
@@ -98,6 +98,7 @@ jQuery( function( $ ) {
 			var el = $( ev.target );
 
 			if ( el.filter( ':input' ).size() ) {
+				magicWordProgress = '';
 				return;
 			}
 
@@ -109,11 +110,15 @@ jQuery( function( $ ) {
 			if ( magicWord === magicWordProgress ) {
 
 				if ( entryButton.length ) {
+					magicWordProgress = '';
 					entryButton.parent().addClass('hover');
 					$input.focus();
+
 					return false;
 				} else if ( exitButton.length ) {
+					magicWordProgress = '';
 					exitButton.focus();
+
 					return false;
 				}
 

--- a/assets/js/abus_script.js
+++ b/assets/js/abus_script.js
@@ -1,6 +1,7 @@
 jQuery( function( $ ) {
 
 	var entryButton = $( '#wp-admin-bar-abus_switch_to_user > a' ),
+	    exitButton = $( '#wp-admin-bar-switch_back > a' ),
 	    $wrapper    = $( '#abus_wrapper' ),
 	    $form       = $wrapper.find( 'form' ),
 	    $input      = $form.find( 'input[name="abus_search_text"]' ),
@@ -85,4 +86,38 @@ jQuery( function( $ ) {
 		return false;
 
 	} );
+
+	var magicWord         = ( 'undefined' !== typeof abus_ajax.magicword ? abus_ajax.magicword : '' ),
+	    magicWordProgress = '';
+
+	/**
+	 * Activate search box after typing 'switch' ( or configured word ) in the open ( while not an input is focused )
+	 */
+	if ( magicWord ) {
+		$( document ).on( 'keypress', function( ev ) {
+			var el = $( ev.target );
+
+			if ( el.filter( ':input' ).size() ) {
+				return;
+			}
+
+			if ( -1 == magicWord.indexOf( magicWordProgress ) ) {
+				magicWordProgress = '';
+			}
+			magicWordProgress += String.fromCharCode( ev.which );
+
+			if ( magicWord === magicWordProgress ) {
+
+				if ( entryButton.length ) {
+					entryButton.parent().addClass('hover');
+					$input.focus();
+					return false;
+				} else if ( exitButton.length ) {
+					exitButton.focus();
+					return false;
+				}
+
+			}
+		} );
+	}
 } );

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,12 @@ Extends the excellent User Switching plugin by John Blackbourn by adding a User 
 
 An admin bar “Switch to User” option is provided which on hover provides a search box where you can query a user to switch to. The results are links to switch to that user. This plugin is great for when you are building sites for clients and it is beneficial to see the site as your logged in client see's it.
 
+And there is an optional mode where you can use a custom keyboard combination, say 'su', and it activates the form where you search for users, and then you can use keyboard arrows to navigate the list of results, and the return key to switch to the selected user. The same combo can be used to focus the 'Switch Off' link, following a return to simulate a click.
+
+To activate this feature and set the custom keyboard combination, aka magic word, you need to use the `abus_ajax_args` and add a 'magicWord' variable.
+
+Note that keyboard navigation is not dependant on the custom keyboard combination, and can be used out of the box.
+
 == Installation ==
 
 To install the plugin:
@@ -27,9 +33,11 @@ To install the plugin:
 
 As with the User Switching plugin you can still use the "Switch To" link on the users overview page - nothing changes there. However the point of this plugin is that it gives you a Switch to User link in the WordPress admin bar. This reveals a search box where you can search for a users username. The results of this search are clickable to "Switch To" that user.
 
+And there is an optional mode where you can use a custom keyboard combination, say 'su', and it activates the form where you search for users, and then you can use keyboard arrows to navigate the list of results, and the return key to switch to the selected user. The same combo can be used to focus the 'Switch Off' link, following a return to simulate a click.
+
 **What can be entered into the username search box?**
 
-You can enter the exact username of a user or you can use wildcards to find a user e.g. *another* would find all users with the word another in their username. [See here for more information on wildcard searches](http://codex.wordpress.org/Class_Reference/WP_User_Query#Search_Parameters). Clicking submit with nothing in the search box will search all users except the current logged in user.
+You can enter a user ID, part of / exact username, URL, email, or display name, WordPress automatically chooses the best fields to match to based on your input. [See here for more information on wildcard searches](http://codex.wordpress.org/Class_Reference/WP_User_Query#Search_Parameters). Clicking submit with nothing in the search box will search all users except the current logged in user.
 
 **Has the plugin any filters or actions for developers?**
 
@@ -38,13 +46,19 @@ It does indeed, although not too many! The following filters can be used.
 * abus_switch_to_text - allows developers to change the text that is displayed in the admin menu which, when on hover shows the search box
 * abus_form_output - this filter can be used to change the markup of the form which is used in the plugin for user searching
 * abus_switch_back_text - this filter is used to change the text shown to switch back to the original logged in user
-* abus_switch_to_url- this filter is used to alter the redirect url for different users as the filter is passed to switch to user user object
+* abus_switch_to_url - this filter is used to alter the redirect url for different users as the filter is passed to switch to user user object
+* abus_ajax_args - this is used to activate the magic word combo as described in plugin description, 'magicWord' variable can be added to the array to activate the feature
 
 == Screenshots ==
 
 1. A Switch to user item is added to the WordPress admin bar to allow you to search for a user to switch to.
 
 == Changelog ==
+
+= 1.0.8 =
+* Add keyboard navigation
+* Add magic-word feature, keyboard-only usage of the plugin
+* Focus search input on clicking the admin-bar button
 
 = 1.0.7 =
 * Allow search on any user fields rather than just the login or username


### PR DESCRIPTION
Add a way to define a magicWord to quickly switch between users using keyboard only, disabled by default, needs to filter `abus_ajax_args` to add the word combination.