### PR TITLE
Don't enqueue abus_script if user isn't logged in

### DIFF
--- a/admin-bar-user-switching.php
+++ b/admin-bar-user-switching.php
@@ -222,8 +222,9 @@ function abus_enqueue_scripts() {
 		$args
 	);        
 	
-	wp_enqueue_script( 'jquery' );
-	wp_enqueue_script( 'abus_script' );
+	if( is_user_logged_in() ) {
+		wp_enqueue_script( 'abus_script' );
+	}
 
 }
 


### PR DESCRIPTION
There is a reason why the script is enqueued even for non logged in users?

By the way, there is no need to enqueue 'jquery' since it is defined as depency.