### PR TITLE
Simplify abus_current_url

### DIFF
--- a/admin-bar-user-switching.php
+++ b/admin-bar-user-switching.php
@@ -15,16 +15,11 @@
  */
 function abus_current_url( $parse = false ) {
 
-	$s = empty( $_SERVER[ 'HTTPS' ] ) ? '' : ( $_SERVER[ 'HTTPS' ] == 'on' ) ? 's' : '';
-	$protocol = substr( strtolower( $_SERVER[ 'SERVER_PROTOCOL' ] ), 0, strpos( strtolower( $_SERVER[ 'SERVER_PROTOCOL' ] ), '/' ) ) . $s;
-	$port = ( $_SERVER[ 'SERVER_PORT' ] == '80') ? '' : ( ":".$_SERVER[ 'SERVER_PORT' ] );
-	
 	if ( $parse ) {
-		return parse_url( $protocol . "://" . $_SERVER[ 'HTTP_HOST' ] . $port . $_SERVER[ 'REQUEST_URI' ] );
+		return parse_url( get_home_url() . $_SERVER[ 'REQUEST_URI' ] );
 	} else { 
-		return $protocol . "://" . $_SERVER[ 'HTTP_HOST' ] . $port . $_SERVER[ 'REQUEST_URI' ];
+		return get_home_url() . $_SERVER[ 'REQUEST_URI' ];
 	}
-	
 }
 
 /**

--- a/admin-bar-user-switching.php
+++ b/admin-bar-user-switching.php
@@ -15,7 +15,7 @@
  */
 function abus_get_redirect_url( $parse = false ) {
 
-	return admin_url();
+	return apply_filters( 'abus_switch_to_redirect', admin_url() );
 }
 
 /**


### PR DESCRIPTION
I'm having trouble with this function on pantheon.io. The reason is that the $_SERVER[ 'SERVER_PORT' ] variable is actually 9172 or something and the site still runs on 80 though. I'm not sure exactly why that is the case but I assume it has to do with the fact that everything is running in docker containers which each have their own port.

I've ran some experiments with the code above, even on a local MAMP running on :8000 and it's working just fine with this code update. 

This code update would also honour whatever setting was done within WordPress in terms of which protocol should be used etc.

Am I missing anything?