### PR TITLE
Only load js script when needed

### DIFF
--- a/admin-bar-user-switching.php
+++ b/admin-bar-user-switching.php
@@ -223,7 +223,10 @@ function abus_enqueue_scripts() {
 		$args
 	);        
 	
-	if( is_user_logged_in() ) {
+	global $user_switching;
+	if( is_user_logged_in() && is_admin_bar_showing() &&
+	    ( current_user_can( apply_filters( 'abus_switch_to_capability', 'edit_users' ) ) || $user_switching->get_old_user() )
+	) {
 		wp_enqueue_script( 'abus_script' );
 	}
 


### PR DESCRIPTION
Ensure the JS file is only loaded for the users who can switch users / for a user who has currently switched.

Right now it loads for every and any logged in users, including our customers.